### PR TITLE
fix the issue caused by Channel.poll()

### DIFF
--- a/src/main/java/org/zrj/rpc/tool/Channel.java
+++ b/src/main/java/org/zrj/rpc/tool/Channel.java
@@ -39,7 +39,11 @@ public class Channel<E> extends SynchronousQueue<E> {
 
     @Override
     public E poll(long timeout, TimeUnit unit) {
-        return queue.poll();
+        try {
+            return queue.poll(timeout, unit);
+        } catch (InterruptedException e) {
+            throw new RuntimeException(e);
+        }
     }
 
 }


### PR DESCRIPTION
This issue resulted in many messages being lost before they could be processed.